### PR TITLE
Fixing evaluation of conditions

### DIFF
--- a/src/Extension/FieldsShowOn.php
+++ b/src/Extension/FieldsShowOn.php
@@ -585,7 +585,7 @@ class FieldsShowOn extends CMSPlugin implements SubscriberInterface
 		{
 			$andPos    = strpos($showon, '[AND]');
 			$orPos     = strpos($showon, '[OR]');
-			$delimiter = $andPos < $orPos || $orPos === false ? '[AND]' : '[OR]';
+			$delimiter = $andPos > $orPos || $orPos === false ? '[AND]' : '[OR]';
 			[$control, $showon] = explode($delimiter, $showon, 2);
 
 			$streamed[] = $control;

--- a/src/Extension/FieldsShowOn.php
+++ b/src/Extension/FieldsShowOn.php
@@ -578,7 +578,7 @@ class FieldsShowOn extends CMSPlugin implements SubscriberInterface
 	 */
 	private function reworkShowOn(string $showon): string
 	{
-		// Split the showon value across '[AND]' and '[OR]'[OR]
+		// Split the showon value across '[AND]' and '[OR]'
 		$streamed = [];
 
 		while (str_contains($showon, '[AND]') || str_contains($showon, '[OR]'))
@@ -587,8 +587,9 @@ class FieldsShowOn extends CMSPlugin implements SubscriberInterface
 			$orPos     = strpos($showon, '[OR]');
 			$delimiter = $andPos > $orPos || $orPos === false ? '[AND]' : '[OR]';
 			[$control, $showon] = explode($delimiter, $showon, 2);
-
-			$streamed[] = $control;
+			
+			// Add the delimiter back so comparisons work
+			$streamed[] = $control . $delimiter;
 		}
 
 		// Remember to add the last bit (or only bit, if there were no boolean operators)

--- a/src/Extension/FieldsShowOn.php
+++ b/src/Extension/FieldsShowOn.php
@@ -609,6 +609,7 @@ class FieldsShowOn extends CMSPlugin implements SubscriberInterface
 			[$formControl, $condition] = explode(':', $item);
 
 			$suffix      = str_ends_with($formControl, '!') ? '!' : '';
+			$formControl = rtrim($formControl,'!');
 			$formControl = array_search($formControl, $this->customFieldMap) ?: $formControl;
 			$item        = $formControl . $suffix . ':' . $condition;
 		}


### PR DESCRIPTION
When evaluating conditions like [OR] and [AND], the delimiter evaluation on line 589 always evaluated to [AND], causing [OR] conditions to fail and throw PHP errors like I reported in #2 .

Now the delimiter and showon evaluates correctly both ways. 

EDIT: Also, `!:` comparisons now correctly evaluate.